### PR TITLE
Hacer que el idioma se pueda determinar programáticamente | WCAG 3.1.1

### DIFF
--- a/src/app/components/app.component/app.component.html
+++ b/src/app/components/app.component/app.component.html
@@ -1,11 +1,12 @@
+<div class="mat-typography">
 <div fxLayout="row" fxLayoutAlign="flex-end center">
     <div id="skip" fxLayout="row" fxLayoutAlign="space-between center" class="horizontal-padding">
-        <a [routerLink]="" fragment="content" class="mat-body">{{'accessibility.skipToContent' | translate}}</a>
+        <a [routerLink]="" fragment="content">{{'accessibility.skipToContent' | translate}}</a>
     </div>
     <!-- Languages menu -->
     <nav class="language-menu" fxLayout="row" fxLayoutAlign="flex-start center">
         <header fxLayout="row" fxLayoutAlign="flex-start center">
-            <p class="mat-body">{{'navigation.languages' | translate}}</p>
+            <p class="no-padding">{{'navigation.languages' | translate}}</p>
         </header>
         <ul fxLayout="row" fxLayoutAlign="flex-start center">
             <li lang="es">
@@ -26,3 +27,4 @@
 </div>
 
 <footer-component></footer-component>
+</div>

--- a/src/app/components/app.component/app.component.html
+++ b/src/app/components/app.component/app.component.html
@@ -20,7 +20,7 @@
         </nav>
     </div>
 
-    <header-component (onClearFocus)="clearFocus()"></header-component>
+    <header-component></header-component>
     <div fxLayout="column" fxLayoutAlign="flex-start center">
         <main class="main-layout-content" id="content" #skipToContentTarget tabindex="0">
             <router-outlet></router-outlet>    

--- a/src/app/components/app.component/app.component.ts
+++ b/src/app/components/app.component/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { DOCUMENT } from '@angular/common'
 
 @Component({
   selector: 'app-root',
@@ -9,13 +10,15 @@ import { TranslateService } from '@ngx-translate/core';
 export class AppComponent{
   title = 'veggieweb';
 
-  constructor(private translateService: TranslateService){
+  constructor(private translateService: TranslateService, @Inject(DOCUMENT) private document: Document) {
     translateService.setDefaultLang('en');
     translateService.use('es');
+    this.document.documentElement.lang = this.translateService.currentLang;
   }
 
   changeLanguage(language:string):void{
     this.translateService.use(language);
+    this.document.documentElement.lang = language;
   }
 
   isLanguageSelected(language:string):Boolean{

--- a/src/app/components/app.component/app.component.ts
+++ b/src/app/components/app.component/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ActivatedRoute} from '@angular/router';
+import { ActivatedRoute, NavigationEnd, NavigationStart, Router} from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { DOCUMENT } from '@angular/common'
 import { HelperService } from 'src/app/services/helper.service/helper.service';
@@ -15,14 +15,27 @@ export class AppComponent{
   @ViewChild("skipToContentTarget") skipToContentTarget?: ElementRef;
   @ViewChild("firstElementTarget") firstElementTarget?: ElementRef;
 
-  constructor(private router:ActivatedRoute, private helperService:HelperService) {
+  previousUrl:string ="";
+
+  constructor(private activateRoute:ActivatedRoute, private router :Router, private helperService:HelperService) {
     this.helperService.setDefaultLanguage('en');
     this.helperService.changeLanguage('es');  
 
-    this.router.fragment.subscribe(fragment=>{
-      if(!!fragment)
+    this.activateRoute.fragment.subscribe(fragment=>{
+      if(!!fragment){
         this.focusContentElement();
+      }
     });
+
+    this.router.events.subscribe(event=>{
+
+      if(event instanceof NavigationEnd){
+        if(this.previousUrl !== "" && event.url !== this.previousUrl+"#content"){
+          this.clearFocus();
+        }
+        this.previousUrl = event.url;
+      }
+    })
 
     this.helperService.onClearFocus.subscribe((targ:any)=>{
       this.clearFocus();
@@ -32,7 +45,6 @@ export class AppComponent{
 
   changeLanguage(language:string):void{
     this.helperService.changeLanguage(language); 
-    this.clearFocus();
   }
 
   isLanguageSelected(language:string):Boolean{

--- a/src/app/components/app.component/app.component.ts
+++ b/src/app/components/app.component/app.component.ts
@@ -24,10 +24,15 @@ export class AppComponent{
         this.focusContentElement();
     });
 
+    this.helperService.onClearFocus.subscribe((targ:any)=>{
+      this.clearFocus();
+    })
+
   }
 
   changeLanguage(language:string):void{
     this.helperService.changeLanguage(language); 
+    this.clearFocus();
   }
 
   isLanguageSelected(language:string):Boolean{
@@ -39,7 +44,6 @@ export class AppComponent{
   }
 
   clearFocus():void{
-    console.log("adsf");
     this.firstElementTarget?.nativeElement.focus();
   }
 

--- a/src/app/components/app.component/app.component.ts
+++ b/src/app/components/app.component/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { DOCUMENT } from '@angular/common'
+import { HelperService } from 'src/app/services/helper.service/helper.service';
 
 @Component({
   selector: 'app-root',
@@ -10,19 +11,17 @@ import { DOCUMENT } from '@angular/common'
 export class AppComponent{
   title = 'veggieweb';
 
-  constructor(private translateService: TranslateService, @Inject(DOCUMENT) private document: Document) {
-    translateService.setDefaultLang('en');
-    translateService.use('es');
-    this.document.documentElement.lang = this.translateService.currentLang;
+  constructor(private helperService:HelperService) {
+    this.helperService.setDefaultLanguage('en');
+    this.helperService.changeLanguage('es');    
   }
 
   changeLanguage(language:string):void{
-    this.translateService.use(language);
-    this.document.documentElement.lang = language;
+    this.helperService.changeLanguage(language); 
   }
 
   isLanguageSelected(language:string):Boolean{
-    return this.translateService.currentLang == language;
+    return this.helperService.getCurrentLang() == language;
   }
 
 }

--- a/src/app/components/contact-page.component/contact-page.component.html
+++ b/src/app/components/contact-page.component/contact-page.component.html
@@ -1,6 +1,6 @@
 <div class="content-section">
     <!-- Section title -->
-    <h2>{{'contactPage.title' | translate}}</h2>
+    <h1>{{'contactPage.title' | translate}}</h1>
     <!-- Description -->
     <p>{{'contactPage.description'| translate}} </p>
 

--- a/src/app/components/footer.component/footer.component.html
+++ b/src/app/components/footer.component/footer.component.html
@@ -35,10 +35,10 @@
                     <li>
                         <h3>{{'footer.navigation' | translate}}</h3>
                         <ul>
-                            <li><a routerLink="../home">{{'navigation.home' | translate}}</a></li>
-                            <li><a routerLink="../veggie/list">{{'navigation.veggies' | translate}}</a></li>
-                            <li><a routerLink="../contact">{{'navigation.contact' | translate}}</a></li>
-                            <li><a routerLink="../sitemap">{{'navigation.sitemap' | translate}}</a></li>
+                            <li><a routerLink="../home" (click)="clearFocus()">{{'navigation.home' | translate}}</a></li>
+                            <li><a routerLink="../veggie/list" (click)="clearFocus()">{{'navigation.veggies' | translate}}</a></li>
+                            <li><a routerLink="../contact" (click)="clearFocus()">{{'navigation.contact' | translate}}</a></li>
+                            <li><a routerLink="../sitemap" (click)="clearFocus()">{{'navigation.sitemap' | translate}}</a></li>
                         </ul>
                     </li>          
                     <li>

--- a/src/app/components/footer.component/footer.component.html
+++ b/src/app/components/footer.component/footer.component.html
@@ -35,10 +35,10 @@
                     <li>
                         <h3>{{'footer.navigation' | translate}}</h3>
                         <ul>
-                            <li><a routerLink="../home" (click)="clearFocus()">{{'navigation.home' | translate}}</a></li>
-                            <li><a routerLink="../veggie/list" (click)="clearFocus()">{{'navigation.veggies' | translate}}</a></li>
-                            <li><a routerLink="../contact" (click)="clearFocus()">{{'navigation.contact' | translate}}</a></li>
-                            <li><a routerLink="../sitemap" (click)="clearFocus()">{{'navigation.sitemap' | translate}}</a></li>
+                            <li><a routerLink="../home">{{'navigation.home' | translate}}</a></li>
+                            <li><a routerLink="../veggie/list">{{'navigation.veggies' | translate}}</a></li>
+                            <li><a routerLink="../contact">{{'navigation.contact' | translate}}</a></li>
+                            <li><a routerLink="../sitemap">{{'navigation.sitemap' | translate}}</a></li>
                         </ul>
                     </li>          
                     <li>

--- a/src/app/components/footer.component/footer.component.html
+++ b/src/app/components/footer.component/footer.component.html
@@ -30,13 +30,30 @@
                 </div>
             </div>
 
-            <nav class="footer-navigation" >
-                <ul>
-                    <li><a routerLink="../home">{{'navigation.home' | translate}}</a></li>
-                    <li><a routerLink="../veggie/list">{{'navigation.veggies' | translate}}</a></li>
-                    <li><a routerLink="../contact">{{'navigation.contact' | translate}}</a></li>
-                    <li><a routerLink="../sitemap">{{'navigation.sitemap' | translate}}</a></li>
+            <nav class="footer-navigation">
+                <ul fxLayout="row" fxLayoutAlign="flex-start flex-start" fxLayoutGap="20px">
+                    <li>
+                        <h3>{{'footer.navigation' | translate}}</h3>
+                        <ul>
+                            <li><a routerLink="../home">{{'navigation.home' | translate}}</a></li>
+                            <li><a routerLink="../veggie/list">{{'navigation.veggies' | translate}}</a></li>
+                            <li><a routerLink="../contact">{{'navigation.contact' | translate}}</a></li>
+                            <li><a routerLink="../sitemap">{{'navigation.sitemap' | translate}}</a></li>
+                        </ul>
+                    </li>          
+                    <li>
+                        <h3>{{'footer.languages' | translate}}</h3>
+                        <ul>
+                            <li lang="es">
+                                <button mat-button color="primary" disabled="{{isLanguageSelected('es')}}" (click)="changeLanguage('es')">Español</button>
+                            </li>
+                            <li lang="en">
+                                <button mat-button color="primary" disabled="{{isLanguageSelected('en')}}" (click)="changeLanguage('en')">English</button>
+                            </li>
+                        </ul>
+                    </li>
                 </ul>
+
             </nav>
         </div>
         <div>

--- a/src/app/components/footer.component/footer.component.ts
+++ b/src/app/components/footer.component/footer.component.ts
@@ -15,10 +15,16 @@ export class FooterComponent implements OnInit {
 
   changeLanguage(language:string):void{
     this.helperService.changeLanguage(language); 
+    this.clearFocus();
   }
 
   isLanguageSelected(language:string):Boolean{
     return this.helperService.getCurrentLang() == language;
   }
+
+  clearFocus():void{
+    this.helperService.clearFocus();
+  }
+
 
 }

--- a/src/app/components/footer.component/footer.component.ts
+++ b/src/app/components/footer.component/footer.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { HelperService } from 'src/app/services/helper.service/helper.service';
 
 @Component({
   selector: 'footer-component',
@@ -8,17 +8,17 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class FooterComponent implements OnInit {
 
-  constructor(private translateService: TranslateService) { }
+  constructor(private helperService:HelperService) { }
 
   ngOnInit(): void {
   }
 
   changeLanguage(language:string):void{
-    this.translateService.use(language);
+    this.helperService.changeLanguage(language); 
   }
 
   isLanguageSelected(language:string):Boolean{
-    return this.translateService.currentLang == language;
+    return this.helperService.getCurrentLang() == language;
   }
 
 }

--- a/src/app/components/header.component/header.component.html
+++ b/src/app/components/header.component/header.component.html
@@ -10,9 +10,9 @@
             <!-- Navigation menu -->
             <nav class="navigation-menu">
                 <ul fxLayout="row" fxLayoutAlign="flex-start center">
-                    <li><a mat-button routerLink="../home" (click)="clearFocus()">{{'navigation.home' | translate}}</a></li>
-                    <li><a mat-button routerLink="../veggie/list" (click)="clearFocus()">{{'navigation.veggies' | translate}}</a></li>
-                    <li><a mat-button routerLink="../contact" (click)="clearFocus()">{{'navigation.contact' | translate}}</a></li>
+                    <li><a mat-button routerLink="../home">{{'navigation.home' | translate}}</a></li>
+                    <li><a mat-button routerLink="../veggie/list">{{'navigation.veggies' | translate}}</a></li>
+                    <li><a mat-button routerLink="../contact">{{'navigation.contact' | translate}}</a></li>
                 </ul>
             </nav>
             

--- a/src/app/components/header.component/header.component.ts
+++ b/src/app/components/header.component/header.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { HelperService } from 'src/app/services/helper.service/helper.service';
 
 @Component({
   selector: 'header-component',
@@ -6,17 +7,14 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent implements OnInit {
-
-  @Output()
-  onClearFocus: EventEmitter<any> = new EventEmitter();
-
-  constructor() { }
+  
+  constructor(private helperService: HelperService) { }
 
   ngOnInit(): void {
   }
 
   clearFocus():void{
-    this.onClearFocus.emit('clear');
+    this.helperService.clearFocus();
   }
 
 }

--- a/src/app/components/home-page.component/home-page.component.scss
+++ b/src/app/components/home-page.component/home-page.component.scss
@@ -7,6 +7,7 @@
     background: #3f51b5;
     background-image: url("https://cdn.pixabay.com/photo/2015/09/18/11/36/plantation-945400_960_720.jpg");
     margin:20px 0;
+    padding: 20px 0;
     h2{
         color: #FFF;
     }

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -1,7 +1,7 @@
 <div class="content-section">
     <!-- Navigation -->
     <nav fxLayout="row" fxLayoutAlign="flex-start center" class="vertical-padding">
-        <a mat-button color="primary" routerLink="../../veggie/list">{{'navigation.veggies' | traslate}</a>
+        <a mat-button color="primary" routerLink="../../veggie/list" (click)="clearFocus()">{{'navigation.veggies' | traslate}</a>
         <a mat-button disabled>{{veggie?.name}}</a>
     </nav>
     <!-- Section title -->

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -1,7 +1,7 @@
 <div class="content-section">
     <!-- Navigation -->
     <nav fxLayout="row" fxLayoutAlign="flex-start center" class="vertical-padding">
-        <a mat-button color="primary" routerLink="../../veggie/list" (click)="clearFocus()">{{'navigation.veggies' | traslate}</a>
+        <a mat-button color="primary" routerLink="../../veggie/list">{{'navigation.veggies' | traslate}</a>
         <a mat-button disabled>{{veggie?.name}}</a>
     </nav>
     <!-- Section title -->

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -6,7 +6,7 @@
     </nav>
     <!-- Section title -->
     <header>
-        <h2>{{veggie?.name}}</h2>
+        <h1>{{veggie?.name}}</h1>
     </header>
 
     <div fxLayout="column" fxLAyoutAlign="start-flex stretch" fxLayout.gt-xs="row" fxLayoutAlign.gt-x="flex-start flex-start" fxLayoutGap="20px">

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
+import { HelperService } from 'src/app/services/helper.service/helper.service';
 import { VeggieService } from 'src/app/services/veggie.service/veggie.service';
 import { CompleteVeggie } from 'src/app/types/completeVeggie';
 
@@ -15,6 +16,7 @@ export class VeggieInfoPageComponent implements OnInit {
   veggie? : CompleteVeggie;
 
   constructor(
+    private helperService: HelperService,
     private translateService: TranslateService, 
     private actRoute: ActivatedRoute,
     private veggieService:VeggieService) 
@@ -42,6 +44,10 @@ export class VeggieInfoPageComponent implements OnInit {
     this.translateService.onLangChange.subscribe((langChangeEvent: LangChangeEvent) => {
       this.getVeggie(langChangeEvent.lang, this.id);
     });
+  }
+
+  clearFocus():void{
+    this.helperService.clearFocus();
   }
 
 }

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
@@ -16,7 +16,6 @@ export class VeggieInfoPageComponent implements OnInit {
   veggie? : CompleteVeggie;
 
   constructor(
-    private helperService: HelperService,
     private translateService: TranslateService, 
     private actRoute: ActivatedRoute,
     private veggieService:VeggieService) 
@@ -46,8 +45,5 @@ export class VeggieInfoPageComponent implements OnInit {
     });
   }
 
-  clearFocus():void{
-    this.helperService.clearFocus();
-  }
 
 }

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.html
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.html
@@ -1,7 +1,7 @@
 <div class="content-section">
     <!-- Section title -->
     <header>
-        <h2>{{'veggieListPage.title' | translate}}</h2>
+        <h1>{{'veggieListPage.title' | translate}}</h1>
     </header>
     <!-- Description -->
     <p>{{'veggieListPage.description'| translate}} </p>

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.html
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.html
@@ -19,7 +19,7 @@
                   <p>{{veggie.description}}</p>
                 </mat-card-content>
                 <mat-card-actions>
-                    <a mat-button [routerLink]="['../../veggie', veggie.id]">{{'veggieListPage.readMore' | translate}}</a>
+                    <a mat-button [routerLink]="['../../veggie', veggie.id]" (click)="clearFocus()">{{'veggieListPage.readMore' | translate}}</a>
                 </mat-card-actions>
               </mat-card>
         </li>
@@ -28,7 +28,7 @@
     <div fxLayout="column" fxLAyoutAlign="flex-start center" class="vertical-padding">
         <p class="text-center">{{'veggieListPage.wantMoreDescription' | translate}}</p>
         <div fxLayout="row" fxLayoutAlign="center center">
-            <a mat-flat-button color="primary" href="../../contact">{{'veggieListPage.wantMore' | translate}}</a>
+            <a mat-flat-button color="primary" href="../../contact" (click)="clearFocus()">{{'veggieListPage.wantMore' | translate}}</a>
         </div>
     </div>
 </div>

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.html
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.html
@@ -19,7 +19,7 @@
                   <p>{{veggie.description}}</p>
                 </mat-card-content>
                 <mat-card-actions>
-                    <a mat-button [routerLink]="['../../veggie', veggie.id]" (click)="clearFocus()">{{'veggieListPage.readMore' | translate}}</a>
+                    <a mat-button [routerLink]="['../../veggie', veggie.id]">{{'veggieListPage.readMore' | translate}}</a>
                 </mat-card-actions>
               </mat-card>
         </li>
@@ -28,7 +28,7 @@
     <div fxLayout="column" fxLAyoutAlign="flex-start center" class="vertical-padding">
         <p class="text-center">{{'veggieListPage.wantMoreDescription' | translate}}</p>
         <div fxLayout="row" fxLayoutAlign="center center">
-            <a mat-flat-button color="primary" href="../../contact" (click)="clearFocus()">{{'veggieListPage.wantMore' | translate}}</a>
+            <a mat-flat-button color="primary" href="../../contact">{{'veggieListPage.wantMore' | translate}}</a>
         </div>
     </div>
 </div>

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, NgZone, OnInit } from '@angular/core';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
+import { HelperService } from 'src/app/services/helper.service/helper.service';
 import { VeggieService } from 'src/app/services/veggie.service/veggie.service';
 import { Veggie } from 'src/app/types/veggie';
 
@@ -14,6 +15,7 @@ export class VeggieListPageComponent implements OnInit {
 
   constructor(
     private zone:NgZone,
+    private helperService: HelperService,
     private translateService: TranslateService, 
     private veggieService:VeggieService) { }
 
@@ -41,4 +43,7 @@ export class VeggieListPageComponent implements OnInit {
     });
   }
 
+  clearFocus():void{
+    this.helperService.clearFocus();
+  }
 }

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
@@ -15,7 +15,6 @@ export class VeggieListPageComponent implements OnInit {
 
   constructor(
     private zone:NgZone,
-    private helperService: HelperService,
     private translateService: TranslateService, 
     private veggieService:VeggieService) { }
 
@@ -43,7 +42,4 @@ export class VeggieListPageComponent implements OnInit {
     });
   }
 
-  clearFocus():void{
-    this.helperService.clearFocus();
-  }
 }

--- a/src/app/services/helper.service/helper.service.spec.ts
+++ b/src/app/services/helper.service/helper.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HelperService } from './helper.service';
+
+describe('HelperService', () => {
+  let service: HelperService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HelperService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/helper.service/helper.service.ts
+++ b/src/app/services/helper.service/helper.service.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Inject, Injectable } from '@angular/core';
+import { EventEmitter, Inject, Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 @Injectable({
@@ -7,6 +7,8 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class HelperService {
 
+  onClearFocus: EventEmitter<any> = new EventEmitter();
+  
   constructor(@Inject(DOCUMENT) private document: Document, private translateService: TranslateService) {}
 
   setDefaultLanguage(language:string):void{
@@ -22,6 +24,9 @@ export class HelperService {
     return this.translateService.currentLang;
   }
 
+  clearFocus():void{
+    this.onClearFocus.emit('clear');
+  }
 
 
 }

--- a/src/app/services/helper.service/helper.service.ts
+++ b/src/app/services/helper.service/helper.service.ts
@@ -18,6 +18,7 @@ export class HelperService {
   changeLanguage(language:string):void{
     this.translateService.use(language)
     this.document.documentElement.lang = this.translateService.currentLang;
+    this.clearFocus();
   }
 
   getCurrentLang():string{

--- a/src/app/services/helper.service/helper.service.ts
+++ b/src/app/services/helper.service/helper.service.ts
@@ -1,0 +1,27 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HelperService {
+
+  constructor(@Inject(DOCUMENT) private document: Document, private translateService: TranslateService) {}
+
+  setDefaultLanguage(language:string):void{
+    this.translateService.setDefaultLang(language);
+  }
+
+  changeLanguage(language:string):void{
+    this.translateService.use(language)
+    this.document.documentElement.lang = this.translateService.currentLang;
+  }
+
+  getCurrentLang():string{
+    return this.translateService.currentLang;
+  }
+
+
+
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,7 +22,10 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 }
 
 .no-margin{
-    margin:0;
+    margin:0 !important;
+}
+.no-padding{
+    margin:0 !important;
 }
 
 a{


### PR DESCRIPTION
Se han hecho pequeños cambios en app.component.ts para que el atributo lang de la etiqueta <html> se ajuste correctamente al cambiar el idioma, para cumplir con WCAG 3.1.1