### PR TITLE
Cambio del título de página dinámicamente | WCAG 2.4.2

### DIFF
--- a/src/app/components/home-page.component/home-page.component.ts
+++ b/src/app/components/home-page.component/home-page.component.ts
@@ -2,6 +2,7 @@ import { Component, NgZone, OnInit } from '@angular/core';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 import { HomeService } from 'src/app/services/home.service/home.service';
 import { HomeData } from 'src/app/types/homeData';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-home-page',
@@ -12,11 +13,19 @@ export class HomePageComponent implements OnInit {
 
   homeData:HomeData[] = [];
 
-  constructor(private zone:NgZone, private translateService:TranslateService, private homeService:HomeService) { }
+  constructor(
+    private zone:NgZone,
+    private translateService:TranslateService,
+    private homeService:HomeService,
+    private titleService: Title
+  ) { }
 
   ngOnInit(): void {
     this.getHomeData(this.translateService.currentLang);
     this.onLangChange();
+    this.translateService.get('homePage.tabTitle').subscribe((translated: string) => {
+      this.titleService.setTitle(translated);
+    })
   }
 
   getHomeData(language:string):void{

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 import { VeggieService } from 'src/app/services/veggie.service/veggie.service';
 import { CompleteVeggie } from 'src/app/types/completeVeggie';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-veggie-info-page',
@@ -17,20 +18,22 @@ export class VeggieInfoPageComponent implements OnInit {
   constructor(
     private translateService: TranslateService, 
     private actRoute: ActivatedRoute,
-    private veggieService:VeggieService) 
-    {
-      this.id = this.actRoute.snapshot.params.id;
-    }
+    private veggieService:VeggieService,
+    private titleService: Title ) 
+  {
+     this.id = this.actRoute.snapshot.params.id;
+  }
 
   ngOnInit(): void {
     this.getVeggie(this.translateService.currentLang, this.id);
-    this.onLangChange(); 
+    this.onLangChange();
   }
 
   getVeggie(language:string, id:number):void{
     this.veggieService.getVeggie(language, id).subscribe(
       res=>{
-          this.veggie = res;      
+          this.veggie = res;
+          this.titleService.setTitle('VeggieWeb | ' + this.veggie?.name);
       },
       err=>{
         alert("Error");

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.ts
@@ -2,6 +2,7 @@ import { Component, NgZone, OnInit } from '@angular/core';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 import { VeggieService } from 'src/app/services/veggie.service/veggie.service';
 import { Veggie } from 'src/app/types/veggie';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-veggie-list-page',
@@ -15,11 +16,16 @@ export class VeggieListPageComponent implements OnInit {
   constructor(
     private zone:NgZone,
     private translateService: TranslateService, 
-    private veggieService:VeggieService) { }
+    private veggieService:VeggieService,
+    private titleService: Title
+  ) { }
 
   ngOnInit(): void {
     this.getVeggies(this.translateService.currentLang);
-    this.onLangChange(); 
+    this.onLangChange();
+    this.translateService.get('veggieListPage.tabTitle').subscribe((translated: string) => {
+      this.titleService.setTitle(translated);
+    })
   }
 
   getVeggies(language:string):void{

--- a/src/assets/i18n/translations.en.json
+++ b/src/assets/i18n/translations.en.json
@@ -4,7 +4,7 @@
     },
 
     "contactPage":{
-        "tabTitle":"Contact us | Veggie",
+        "tabTitle":"VeggieWeb | Contact us",
         
         "title":"Contact us",
         "description":"You can use this form to suggest new vegetables to add to our web page. This way, you can help other users looking for information.",

--- a/src/assets/i18n/translations.es.json
+++ b/src/assets/i18n/translations.es.json
@@ -4,7 +4,7 @@
     },
 
     "contactPage":{
-        "tabTitle":"Contáctanos | Veggie",
+        "tabTitle":"VeggieWeb | Contáctanos",
 
         "title":"Contáctanos",
         "description":"Puedes usar este formulario para ponerte en contacto con nosotros y sugerir nuevas hortalizas para añadir o realizar comentarios generales sobre la página. De este modo, nos ayudas y ayudas a otras personas que visiten la página en un futuro.",


### PR DESCRIPTION
Cambios en el ngOnInit de las diferentes páginas para que se actualice el título de la pestaña en el navegador dependiendo de la pestaña en la que se encuentre, para cumplir WCAG 2.4.2

En veggie-info-page el título cambia dependiendo de la hortaliza que se esté mostrando, pero quizá se podría mejorar la forma en la que se hace