### PR TITLE
Textos alternativos en imágenes, y adaptados types y assets \ WCAG 1.1.1

### DIFF
--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -13,7 +13,7 @@
         <div fxLayout="column" fxLayoutAlign="flex-start stretch" fxFlex="60">      
             <h3>{{'veggieInfoPage.description' | translate}}</h3>    
             <div class="veggie-photo">
-                <img [src]="veggie?.photoUrl"/>
+                <img [src]="veggie?.photoUrl" alt={{veggie?.photoDescription}}/>
             </div>
             <!-- Description -->
             <p>{{veggie?.description}} </p>   

--- a/src/app/components/veggie-list-page.component/veggie-list-page.component.html
+++ b/src/app/components/veggie-list-page.component/veggie-list-page.component.html
@@ -10,7 +10,7 @@
     <ul  class="veggie-grid">
         <li *ngFor="let veggie of veggies">
             <mat-card>
-                <img mat-card-image [src]="veggie.photoUrl" alt="veggie.altPhoto">
+                <img mat-card-image [src]="veggie.photoUrl" alt={{veggie.photoDescription}}>
                 <mat-card-content>
                     <h3>
                         <mat-card-title>{{veggie.name}}</mat-card-title>

--- a/src/app/types/completeVeggie.ts
+++ b/src/app/types/completeVeggie.ts
@@ -10,9 +10,9 @@ export class CompleteVeggie extends Veggie{
     maxTemperature:number;
     plantInstructions:PlantInstruction[];
 
-    constructor(id:number, name:string, type:string, description:string, photoUrl:string, plantSeasson:string, harvestSeasson:string, minHumidity:number, maxHumidity:number, 
-        minTemperature:number, maxTemperature:number, plantInstructions:PlantInstruction[]){
-        super(id, name, type, description, photoUrl);
+    constructor(id:number, name:string, type:string, description:string, photoUrl:string, photoDescription:string, plantSeasson:string, harvestSeasson:string, minHumidity:number,
+        maxHumidity:number, minTemperature:number, maxTemperature:number, plantInstructions:PlantInstruction[]){
+        super(id, name, type, description, photoUrl, photoDescription);
         this.plantSeasson = plantSeasson;
         this.harvestSeasson = harvestSeasson;
         this.minHumidity = minHumidity;

--- a/src/app/types/veggie.ts
+++ b/src/app/types/veggie.ts
@@ -4,12 +4,14 @@ export class Veggie{
     type:string;
     description:string;
     photoUrl:string;
+    photoDescription:string;
 
-    constructor(id:number, name:string, type:string, description:string, photoUrl:string){
+    constructor(id:number, name:string, type:string, description:string, photoUrl:string, photoDescription:string){
         this.id = id;
         this.name = name;
         this.type = type;
         this.description = description;
         this.photoUrl = photoUrl;
+        this.photoDescription = photoDescription;
     }
 }

--- a/src/assets/fakeData/veggieData.en.json
+++ b/src/assets/fakeData/veggieData.en.json
@@ -1,30 +1,34 @@
 [
     {
         "id":0,
-        "name":"tomate",
+        "name":"Tomato",
         "type":"fruit",
         "description":"English description of tomate",
-        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+        "photoDescription":"Three red tomatoes"
     },
     {
         "id":1,
-        "name":"potato",
+        "name":"Potato",
         "type":"tuber",
         "description":"English description of potato",
-        "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg",
+        "photoDescription":"A set of potatoes"
     },
     {
         "id":2,
-        "name":"carrot",
+        "name":"Carrot",
         "type":"tuber",
         "description":"English description of carrot",
-        "photoUrl":"https://cdn.pixabay.com/photo/2015/12/08/01/00/carrots-1082251_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2015/12/08/01/00/carrots-1082251_960_720.jpg",
+        "photoDescription":"A set of carrots"
     },
     {
         "id":3,
-        "name":"lettuce",
+        "name":"Lettuce",
         "type":"vegetable",
         "description":"English description of lettuce",
-        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/24/23/19/salad-3560274_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/24/23/19/salad-3560274_960_720.jpg",
+        "photoDescription":"Some lettude leaves"
     }
 ]

--- a/src/assets/fakeData/veggieData.es.json
+++ b/src/assets/fakeData/veggieData.es.json
@@ -1,30 +1,34 @@
 [
     {
         "id":0,
-        "name":"tomate",
+        "name":"Tomate",
         "type":"fruta",
         "description":"Descripción española del tomate",
-        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+        "photoDescription":"Tres tomates rojos"
     },
     {
         "id":1,
-        "name":"patata",
+        "name":"Patata",
         "type":"tubérculo",
         "description":"Descripción española de la patata",
-        "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg",
+        "photoDescription":"Un conjunto de patatas"
     },
     {
         "id":2,
-        "name":"zanahoria",
+        "name":"Zanahoria",
         "type":"tubérculo",
         "description":"Descripción española de la zanahoria",
-        "photoUrl":"https://cdn.pixabay.com/photo/2015/12/08/01/00/carrots-1082251_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2015/12/08/01/00/carrots-1082251_960_720.jpg",
+        "photoDescription":"Un conjunto de zanahorias"
     },
     {
         "id":2,
-        "name":"lechuga",
+        "name":"Lechuga",
         "type":"vedura",
         "description":"Descripción española de la lechuga",
-        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/24/23/19/salad-3560274_960_720.jpg"
+        "photoUrl":"https://cdn.pixabay.com/photo/2018/07/24/23/19/salad-3560274_960_720.jpg",
+        "photoDescription":"Unas hojas de lechuga"
     }
 ]

--- a/src/assets/fakeData/veggieInfo/0.en.json
+++ b/src/assets/fakeData/veggieInfo/0.en.json
@@ -1,8 +1,9 @@
 {
     "id":0,
-    "name":"tomate",
+    "name":"Tomato",
     "description":"Tomate English description",
     "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+    "photoDescription":"Three red tomatoes",
     "plantSeasson":"Summer",
     "harvestSeasson":"Winter",
     "minHumidity":"20%",

--- a/src/assets/fakeData/veggieInfo/0.es.json
+++ b/src/assets/fakeData/veggieInfo/0.es.json
@@ -3,6 +3,7 @@
     "name":"tomate",
     "description":"Descripción española del tomate",
     "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+    "photoDescription":"Tres tomates rojos",
     "plantSeasson":"Verano",
     "harvestSeasson":"Invierno",
     "minHumidity":"20%",

--- a/src/assets/fakeData/veggieInfo/1.en.json
+++ b/src/assets/fakeData/veggieInfo/1.en.json
@@ -1,8 +1,9 @@
 {
     "id":0,
-    "name":"potato",
+    "name":"Potato",
     "description":"Potato English description",
-    "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+    "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg",
+    "photoDescription":"A set of potatoes",
     "plantSeasson":"Summer",
     "harvestSeasson":"Winter",
     "minHumidity":"20%",

--- a/src/assets/fakeData/veggieInfo/1.es.json
+++ b/src/assets/fakeData/veggieInfo/1.es.json
@@ -1,8 +1,9 @@
 {
     "id":0,
-    "name":"patata",
+    "name":"Patata",
     "description":"Descripción española de la patata",
-    "photoUrl":"https://cdn.pixabay.com/photo/2018/07/06/08/49/tomato-3520004_960_720.jpg",
+    "photoUrl":"https://cdn.pixabay.com/photo/2017/05/20/19/51/potatoes-2329648_960_720.jpg",
+    "photoDescription":"Un conjunto de patatas",
     "plantSeasson":"Verano",
     "harvestSeasson":"Invierno",
     "minHumidity":"20%",


### PR DESCRIPTION
Añadidos textos alternativos en imágenes de la página de lista de hortalizas y de la página de información de hortaliza. Adatpados los types veggie y completeveggie para que tengan la descripción de la imagen, así como los json de información de las hortalizas.

Con esto creo que se cumpliría el apartado 1.1.1 de WCAG 2.1