### PR TITLE
Añadida cabecera a la tabla de propiedades de hortaliza | WCAG 1.3.1

### DIFF
--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -23,8 +23,8 @@
             <h3>{{'veggieInfoPage.data' | translate}}</h3>
             <table>
                 <thead>
-                        <td>{{'veggieInfoPage.tableHeaderDataName'}}</td>
-                        <td>{{'veggieInfoPage.tableHeaderDataValue'}}</td>
+                        <td>{{'veggieInfoPage.tableHeaderDataName' | translate}}</td>
+                        <td>{{'veggieInfoPage.tableHeaderDataValue' | translate}}</td>
                 </thead>
                 <tbody>
                     <tr>

--- a/src/app/components/veggie-info-page.component/veggie-info-page.component.html
+++ b/src/app/components/veggie-info-page.component/veggie-info-page.component.html
@@ -23,8 +23,8 @@
             <h3>{{'veggieInfoPage.data' | translate}}</h3>
             <table>
                 <thead>
-                        <td></td>
-                        <td></td>
+                        <td>{{'veggieInfoPage.tableHeaderDataName'}}</td>
+                        <td>{{'veggieInfoPage.tableHeaderDataValue'}}</td>
                 </thead>
                 <tbody>
                     <tr>


### PR DESCRIPTION
Añadidos valores a la cabecera de la tabla de propiedades de las hortalizas, necesario para pasar el punto 1.3.1 de WCAG 2.1